### PR TITLE
Fix broken icons in README with HTML img tags

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,10 +132,10 @@
 
 | Icons                                | Meaning                                                                                                           |
 |--------------------------------------|-------------------------------------------------------------------------------------------------------------------|
-| ![image](assets/documentation/1.png) | Enter / Exit the nest (click before on the nest you created on one circle)                                        |
-| ![image](assets/documentation/3.png) | Toggle points snapping (if not enabled, you can move freely the points, else they snap in rounded position - 15°) |
-| ![image](assets/documentation/4.png) | Toggle auto-separate points when you drag them                                                                    |
-| ![image](assets/documentation/5.jpg) | Enter the nest management dialog, where you can view, add and remove the nests                                    |
+| <img src="/assets/1.png" height="80"/>| Enter / Exit the nest (click before on the nest you created on one circle)                                        |
+| <img src="/assets/3.png" height="60"/>| Toggle points snapping (if not enabled, you can move freely the points, else they snap in rounded position - 15°) |
+| <img src="/assets/2.png" height="60"/> | Toggle auto-separate points when you drag them                                                                    |
+| <img src="/assets/4.png" height="60"/> | Enter the nest management dialog, where you can view, add and remove the nests                                    |
 
 
 ## Signing


### PR DESCRIPTION
This pull request updates the icon display in the `README.md` to improve visual consistency and clarity. The main changes involve switching from Markdown image syntax to HTML image tags, updating image paths, and adjusting icon sizes.

**Documentation improvements:**

* Changed icon references in the icon legend table from Markdown image syntax to HTML `<img>` tags for better control over sizing and appearance.
* Updated image paths to use `/assets/` instead of `/assets/documentation/`, and adjusted the order of icons to match their intended functions.
* Set explicit heights for each icon to ensure consistent visual presentation in the table.