### PR TITLE
feat: Lock settings with PIN, biometric, or device credentials (#81)

### DIFF
--- a/core/enumsui/src/main/java/org/elnix/dragonlauncher/enumsui/LockMethod.kt
+++ b/core/enumsui/src/main/java/org/elnix/dragonlauncher/enumsui/LockMethod.kt
@@ -1,0 +1,18 @@
+package org.elnix.dragonlauncher.enumsui
+
+/**
+ * Available methods for locking the settings screen.
+ */
+enum class LockMethod {
+    /** No lock — settings are freely accessible */
+    NONE,
+
+    /** Require a user-defined PIN code */
+    PIN,
+
+    /** Require biometric authentication (fingerprint) */
+    BIOMETRIC,
+
+    /** Use Android device credentials (pattern / PIN / password) */
+    DEVICE_CREDENTIALS
+}

--- a/core/settings/src/main/java/org/elnix/dragonlauncher/settings/stores/BehaviorSettingsStore.kt
+++ b/core/settings/src/main/java/org/elnix/dragonlauncher/settings/stores/BehaviorSettingsStore.kt
@@ -1,6 +1,7 @@
 package org.elnix.dragonlauncher.settings.stores
 
 import org.elnix.dragonlauncher.common.serializables.SwipeActionSerializable
+import org.elnix.dragonlauncher.enumsui.LockMethod
 import org.elnix.dragonlauncher.settings.DataStoreName
 import org.elnix.dragonlauncher.settings.Settings
 import org.elnix.dragonlauncher.settings.bases.BaseSettingObject
@@ -21,7 +22,8 @@ object BehaviorSettingsStore : MapSettingsStore() {
             leftPadding,
             rightPadding,
             topPadding,
-            bottomPadding
+            bottomPadding,
+            lockMethod
         )
 
     val backAction = Settings.swipeAction(
@@ -70,5 +72,12 @@ object BehaviorSettingsStore : MapSettingsStore() {
         key = "downPadding",
         dataStoreName = BackupSettingsStore.dataStoreName,
         default = 100
+    )
+
+    val lockMethod = Settings.enum(
+        key = "lockMethod",
+        dataStoreName = dataStoreName,
+        default = LockMethod.NONE,
+        enumClass = LockMethod::class.java
     )
 }

--- a/core/settings/src/main/java/org/elnix/dragonlauncher/settings/stores/PrivateSettingsStore.kt
+++ b/core/settings/src/main/java/org/elnix/dragonlauncher/settings/stores/PrivateSettingsStore.kt
@@ -40,11 +40,19 @@ object PrivateSettingsStore : MapSettingsStore() {
         default = 0
     )
 
+    /** Hashed PIN for settings lock (SHA-256). Empty string means no PIN set. */
+    val lockPinHash = Settings.string(
+        key = "lockPinHash",
+        dataStoreName = dataStoreName,
+        default = ""
+    )
+
     override val ALL: List<BaseSettingObject<*,*>> = listOf(
         hasSeenWelcome,
         hasInitialized,
         showSetDefaultLauncherBanner,
         showMethodAsking,
-        lastSeenVersionCode
+        lastSeenVersionCode,
+        lockPinHash
     )
 }

--- a/core/ui/build.gradle.kts
+++ b/core/ui/build.gradle.kts
@@ -64,6 +64,7 @@ dependencies {
     implementation(libs.androidx.ui.graphics)
     implementation(libs.androidx.compose.foundation.layout)
     implementation(libs.androidx.appcompat)
+    implementation(libs.androidx.biometric)
     implementation(libs.androidx.glance.appwidget)
     implementation(libs.androidx.material3)
     implementation(libs.androidx.material.icons.extended)

--- a/core/ui/src/main/java/org/elnix/dragonlauncher/ui/dialogs/PinDialogs.kt
+++ b/core/ui/src/main/java/org/elnix/dragonlauncher/ui/dialogs/PinDialogs.kt
@@ -1,0 +1,294 @@
+package org.elnix.dragonlauncher.ui.dialogs
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.text.KeyboardActions
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Lock
+import androidx.compose.material.icons.filled.Visibility
+import androidx.compose.material.icons.filled.VisibilityOff
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.Button
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.material3.TextField
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.focus.FocusRequester
+import androidx.compose.ui.focus.focusRequester
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.input.ImeAction
+import androidx.compose.ui.text.input.KeyboardType
+import androidx.compose.ui.text.input.PasswordVisualTransformation
+import androidx.compose.ui.text.input.VisualTransformation
+import androidx.compose.ui.unit.dp
+import org.elnix.dragonlauncher.common.R
+import org.elnix.dragonlauncher.ui.UiConstants.DragonShape
+import org.elnix.dragonlauncher.ui.colors.AppObjectsColors
+
+/**
+ * Dialog for entering a PIN to unlock settings.
+ */
+@Composable
+fun PinUnlockDialog(
+    onDismiss: () -> Unit,
+    onPinEntered: (String) -> Unit,
+    errorMessage: String? = null
+) {
+    var pin by remember { mutableStateOf("") }
+    var passwordVisible by remember { mutableStateOf(false) }
+    val focusRequester = remember { FocusRequester() }
+
+    LaunchedEffect(Unit) {
+        focusRequester.requestFocus()
+    }
+
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        confirmButton = {
+            Button(
+                onClick = { onPinEntered(pin) },
+                enabled = pin.length >= 4,
+                colors = AppObjectsColors.buttonColors()
+            ) {
+                Text(
+                    text = stringResource(R.string.unlock_settings),
+                    color = MaterialTheme.colorScheme.onPrimary,
+                    style = MaterialTheme.typography.labelLarge
+                )
+            }
+        },
+        dismissButton = {
+            TextButton(
+                onClick = onDismiss,
+                colors = AppObjectsColors.cancelButtonColors()
+            ) {
+                Text(
+                    text = stringResource(R.string.cancel),
+                    color = MaterialTheme.colorScheme.error,
+                    style = MaterialTheme.typography.labelLarge
+                )
+            }
+        },
+        icon = {
+            Icon(
+                imageVector = Icons.Default.Lock,
+                contentDescription = null,
+                tint = MaterialTheme.colorScheme.primary,
+                modifier = Modifier.size(32.dp)
+            )
+        },
+        title = {
+            Text(
+                text = stringResource(R.string.enter_pin),
+                style = MaterialTheme.typography.titleLarge
+            )
+        },
+        text = {
+            Column(
+                horizontalAlignment = Alignment.CenterHorizontally,
+                verticalArrangement = Arrangement.spacedBy(8.dp)
+            ) {
+                TextField(
+                    value = pin,
+                    onValueChange = { newValue ->
+                        if (newValue.all { it.isDigit() }) {
+                            pin = newValue
+                        }
+                    },
+                    label = { Text(stringResource(R.string.enter_pin)) },
+                    singleLine = true,
+                    visualTransformation = if (passwordVisible) VisualTransformation.None else PasswordVisualTransformation(),
+                    keyboardOptions = KeyboardOptions(
+                        keyboardType = KeyboardType.NumberPassword,
+                        imeAction = ImeAction.Done
+                    ),
+                    keyboardActions = KeyboardActions(
+                        onDone = { if (pin.length >= 4) onPinEntered(pin) }
+                    ),
+                    trailingIcon = {
+                        IconButton(onClick = { passwordVisible = !passwordVisible }) {
+                            Icon(
+                                imageVector = if (passwordVisible) Icons.Default.VisibilityOff else Icons.Default.Visibility,
+                                contentDescription = null
+                            )
+                        }
+                    },
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .focusRequester(focusRequester)
+                )
+
+                if (errorMessage != null) {
+                    Text(
+                        text = errorMessage,
+                        color = MaterialTheme.colorScheme.error,
+                        style = MaterialTheme.typography.bodySmall
+                    )
+                }
+            }
+        },
+        containerColor = MaterialTheme.colorScheme.surface,
+        shape = DragonShape
+    )
+}
+
+
+/**
+ * Dialog for setting up a new PIN (enter + confirm).
+ */
+@Composable
+fun PinSetupDialog(
+    onDismiss: () -> Unit,
+    onPinSet: (String) -> Unit
+) {
+    var pin by remember { mutableStateOf("") }
+    var confirmPin by remember { mutableStateOf("") }
+    var passwordVisible by remember { mutableStateOf(false) }
+    var errorMessage by remember { mutableStateOf<String?>(null) }
+    val focusRequester = remember { FocusRequester() }
+
+    val pinTooShort = stringResource(R.string.pin_too_short)
+    val pinMismatch = stringResource(R.string.pin_mismatch)
+
+    LaunchedEffect(Unit) {
+        focusRequester.requestFocus()
+    }
+
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        confirmButton = {
+            Button(
+                onClick = {
+                    when {
+                        pin.length < 4 -> errorMessage = pinTooShort
+                        pin != confirmPin -> errorMessage = pinMismatch
+                        else -> onPinSet(pin)
+                    }
+                },
+                enabled = pin.length >= 4 && confirmPin.isNotEmpty(),
+                colors = AppObjectsColors.buttonColors()
+            ) {
+                Text(
+                    text = stringResource(R.string.set_pin),
+                    color = MaterialTheme.colorScheme.onPrimary,
+                    style = MaterialTheme.typography.labelLarge
+                )
+            }
+        },
+        dismissButton = {
+            TextButton(
+                onClick = onDismiss,
+                colors = AppObjectsColors.cancelButtonColors()
+            ) {
+                Text(
+                    text = stringResource(R.string.cancel),
+                    color = MaterialTheme.colorScheme.error,
+                    style = MaterialTheme.typography.labelLarge
+                )
+            }
+        },
+        icon = {
+            Icon(
+                imageVector = Icons.Default.Lock,
+                contentDescription = null,
+                tint = MaterialTheme.colorScheme.primary,
+                modifier = Modifier.size(32.dp)
+            )
+        },
+        title = {
+            Text(
+                text = stringResource(R.string.set_pin),
+                style = MaterialTheme.typography.titleLarge
+            )
+        },
+        text = {
+            Column(
+                horizontalAlignment = Alignment.CenterHorizontally,
+                verticalArrangement = Arrangement.spacedBy(8.dp)
+            ) {
+                TextField(
+                    value = pin,
+                    onValueChange = { newValue ->
+                        if (newValue.all { it.isDigit() }) {
+                            pin = newValue
+                            errorMessage = null
+                        }
+                    },
+                    label = { Text(stringResource(R.string.enter_pin)) },
+                    singleLine = true,
+                    visualTransformation = if (passwordVisible) VisualTransformation.None else PasswordVisualTransformation(),
+                    keyboardOptions = KeyboardOptions(
+                        keyboardType = KeyboardType.NumberPassword,
+                        imeAction = ImeAction.Next
+                    ),
+                    trailingIcon = {
+                        IconButton(onClick = { passwordVisible = !passwordVisible }) {
+                            Icon(
+                                imageVector = if (passwordVisible) Icons.Default.VisibilityOff else Icons.Default.Visibility,
+                                contentDescription = null
+                            )
+                        }
+                    },
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .focusRequester(focusRequester)
+                )
+
+                TextField(
+                    value = confirmPin,
+                    onValueChange = { newValue ->
+                        if (newValue.all { it.isDigit() }) {
+                            confirmPin = newValue
+                            errorMessage = null
+                        }
+                    },
+                    label = { Text(stringResource(R.string.confirm_pin)) },
+                    singleLine = true,
+                    visualTransformation = if (passwordVisible) VisualTransformation.None else PasswordVisualTransformation(),
+                    keyboardOptions = KeyboardOptions(
+                        keyboardType = KeyboardType.NumberPassword,
+                        imeAction = ImeAction.Done
+                    ),
+                    keyboardActions = KeyboardActions(
+                        onDone = {
+                            when {
+                                pin.length < 4 -> errorMessage = pinTooShort
+                                pin != confirmPin -> errorMessage = pinMismatch
+                                else -> onPinSet(pin)
+                            }
+                        }
+                    ),
+                    modifier = Modifier.fillMaxWidth()
+                )
+
+                if (errorMessage != null) {
+                    Text(
+                        text = errorMessage!!,
+                        color = MaterialTheme.colorScheme.error,
+                        style = MaterialTheme.typography.bodySmall
+                    )
+                }
+            }
+        },
+        containerColor = MaterialTheme.colorScheme.surface,
+        shape = DragonShape
+    )
+}

--- a/core/ui/src/main/java/org/elnix/dragonlauncher/ui/helpers/SecurityHelper.kt
+++ b/core/ui/src/main/java/org/elnix/dragonlauncher/ui/helpers/SecurityHelper.kt
@@ -1,0 +1,148 @@
+package org.elnix.dragonlauncher.ui.helpers
+
+import android.app.KeyguardManager
+import android.content.Context
+import androidx.biometric.BiometricManager
+import androidx.biometric.BiometricPrompt
+import androidx.core.content.ContextCompat
+import androidx.fragment.app.FragmentActivity
+import org.elnix.dragonlauncher.common.R
+import java.security.MessageDigest
+
+/**
+ * Utility object for settings lock security operations.
+ */
+object SecurityHelper {
+
+    /**
+     * Hashes a PIN using SHA-256.
+     */
+    fun hashPin(pin: String): String {
+        val digest = MessageDigest.getInstance("SHA-256")
+        val hashBytes = digest.digest(pin.toByteArray(Charsets.UTF_8))
+        return hashBytes.joinToString("") { "%02x".format(it) }
+    }
+
+    /**
+     * Verifies a PIN against a stored hash.
+     */
+    fun verifyPin(pin: String, storedHash: String): Boolean {
+        return hashPin(pin) == storedHash
+    }
+
+    /**
+     * Checks if biometric authentication is available on this device.
+     */
+    fun isBiometricAvailable(context: Context): Boolean {
+        val biometricManager = BiometricManager.from(context)
+        return biometricManager.canAuthenticate(BiometricManager.Authenticators.BIOMETRIC_STRONG) ==
+                BiometricManager.BIOMETRIC_SUCCESS ||
+                biometricManager.canAuthenticate(BiometricManager.Authenticators.BIOMETRIC_WEAK) ==
+                BiometricManager.BIOMETRIC_SUCCESS
+    }
+
+    /**
+     * Checks if device credentials (screen lock) are set up.
+     */
+    fun isDeviceCredentialAvailable(context: Context): Boolean {
+        val keyguardManager = context.getSystemService(Context.KEYGUARD_SERVICE) as KeyguardManager
+        return keyguardManager.isDeviceSecure
+    }
+
+    /**
+     * Shows a biometric prompt for authentication.
+     */
+    fun showBiometricPrompt(
+        activity: FragmentActivity,
+        onSuccess: () -> Unit,
+        onError: (String) -> Unit,
+        onFailed: () -> Unit
+    ) {
+        val executor = ContextCompat.getMainExecutor(activity)
+
+        val callback = object : BiometricPrompt.AuthenticationCallback() {
+            override fun onAuthenticationSucceeded(result: BiometricPrompt.AuthenticationResult) {
+                super.onAuthenticationSucceeded(result)
+                onSuccess()
+            }
+
+            override fun onAuthenticationError(errorCode: Int, errString: CharSequence) {
+                super.onAuthenticationError(errorCode, errString)
+                // User cancelled — not a real error, just dismiss
+                if (errorCode == BiometricPrompt.ERROR_USER_CANCELED ||
+                    errorCode == BiometricPrompt.ERROR_NEGATIVE_BUTTON ||
+                    errorCode == BiometricPrompt.ERROR_CANCELED
+                ) {
+                    onFailed()
+                } else {
+                    onError(errString.toString())
+                }
+            }
+
+            override fun onAuthenticationFailed() {
+                super.onAuthenticationFailed()
+                onFailed()
+            }
+        }
+
+        val biometricPrompt = BiometricPrompt(activity, executor, callback)
+
+        val promptInfo = BiometricPrompt.PromptInfo.Builder()
+            .setTitle(activity.getString(R.string.biometric_prompt_title))
+            .setSubtitle(activity.getString(R.string.biometric_prompt_subtitle))
+            .setNegativeButtonText(activity.getString(R.string.cancel))
+            .setAllowedAuthenticators(
+                BiometricManager.Authenticators.BIOMETRIC_STRONG or
+                        BiometricManager.Authenticators.BIOMETRIC_WEAK
+            )
+            .build()
+
+        biometricPrompt.authenticate(promptInfo)
+    }
+
+    /**
+     * Shows a device credentials prompt (pattern / PIN / password).
+     */
+    fun showDeviceCredentialPrompt(
+        activity: FragmentActivity,
+        onSuccess: () -> Unit,
+        onError: (String) -> Unit,
+        onFailed: () -> Unit
+    ) {
+        val executor = ContextCompat.getMainExecutor(activity)
+
+        val callback = object : BiometricPrompt.AuthenticationCallback() {
+            override fun onAuthenticationSucceeded(result: BiometricPrompt.AuthenticationResult) {
+                super.onAuthenticationSucceeded(result)
+                onSuccess()
+            }
+
+            override fun onAuthenticationError(errorCode: Int, errString: CharSequence) {
+                super.onAuthenticationError(errorCode, errString)
+                if (errorCode == BiometricPrompt.ERROR_USER_CANCELED ||
+                    errorCode == BiometricPrompt.ERROR_NEGATIVE_BUTTON ||
+                    errorCode == BiometricPrompt.ERROR_CANCELED
+                ) {
+                    onFailed()
+                } else {
+                    onError(errString.toString())
+                }
+            }
+
+            override fun onAuthenticationFailed() {
+                super.onAuthenticationFailed()
+                onFailed()
+            }
+        }
+
+        val biometricPrompt = BiometricPrompt(activity, executor, callback)
+
+        val promptInfo = BiometricPrompt.PromptInfo.Builder()
+            .setTitle(activity.getString(R.string.biometric_prompt_title))
+            .setSubtitle(activity.getString(R.string.biometric_prompt_subtitle))
+            .setAllowedAuthenticators(BiometricManager.Authenticators.DEVICE_CREDENTIAL)
+            .build()
+
+        biometricPrompt.authenticate(promptInfo)
+    }
+}

--- a/core/ui/src/main/java/org/elnix/dragonlauncher/ui/settings/SettingsNavHost.kt
+++ b/core/ui/src/main/java/org/elnix/dragonlauncher/ui/settings/SettingsNavHost.kt
@@ -12,30 +12,40 @@ import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
+import androidx.fragment.app.FragmentActivity
 import androidx.navigation.NavType
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
 import androidx.navigation.compose.currentBackStackEntryAsState
 import androidx.navigation.compose.rememberNavController
 import androidx.navigation.navArgument
+import kotlinx.coroutines.launch
 import org.elnix.dragonlauncher.common.FloatingAppObject
+import org.elnix.dragonlauncher.common.R
 import org.elnix.dragonlauncher.common.logging.logE
 import org.elnix.dragonlauncher.common.serializables.defaultSwipePointsValues
 import org.elnix.dragonlauncher.common.utils.SETTINGS
 import org.elnix.dragonlauncher.common.utils.WidgetHostProvider
+import org.elnix.dragonlauncher.common.utils.showToast
 import org.elnix.dragonlauncher.common.utils.transparentScreens
+import org.elnix.dragonlauncher.enumsui.LockMethod
 import org.elnix.dragonlauncher.models.AppLifecycleViewModel
 import org.elnix.dragonlauncher.models.AppsViewModel
 import org.elnix.dragonlauncher.models.BackupViewModel
 import org.elnix.dragonlauncher.models.FloatingAppsViewModel
+import org.elnix.dragonlauncher.settings.stores.BehaviorSettingsStore
 import org.elnix.dragonlauncher.settings.stores.DrawerSettingsStore
+import org.elnix.dragonlauncher.settings.stores.PrivateSettingsStore
 import org.elnix.dragonlauncher.settings.stores.SwipeSettingsStore
 import org.elnix.dragonlauncher.ui.AdvancedSettingsScreen
 import org.elnix.dragonlauncher.ui.SettingsScreen
+import org.elnix.dragonlauncher.ui.dialogs.PinUnlockDialog
+import org.elnix.dragonlauncher.ui.helpers.SecurityHelper
 import org.elnix.dragonlauncher.ui.helpers.noAnimComposable
 import org.elnix.dragonlauncher.ui.settings.backup.BackupTab
 import org.elnix.dragonlauncher.ui.settings.customization.AppearanceTab
@@ -76,14 +86,27 @@ fun SettingsNavHost(
     onRemoveFloatingApp: (FloatingAppObject) -> Unit
 ) {
     val ctx = LocalContext.current
+    val scope = rememberCoroutineScope()
+
+
+    // ── Lock gate state ──
+    val lockMethod by BehaviorSettingsStore.lockMethod.flow(ctx)
+        .collectAsState(initial = LockMethod.NONE)
+    val pinHash by PrivateSettingsStore.lockPinHash.flow(ctx)
+        .collectAsState(initial = "")
+
+    /** Once unlocked during this session, stay unlocked */
+    var isUnlocked by remember { mutableStateOf(false) }
+    var showPinDialog by remember { mutableStateOf(false) }
+    var pinError by remember { mutableStateOf<String?>(null) }
 
 
     LaunchedEffect(Unit) {
         appLifecycleViewModel.homeEvents.collect {
+            isUnlocked = false
             goMainScreen()
         }
     }
-
 
 
 
@@ -108,7 +131,60 @@ fun SettingsNavHost(
 
     var pendingNestToEdit by remember { mutableStateOf<Int?>(null) }
 
-    fun goAdvSettingsRoot() =  navController.navigate(SETTINGS.ADVANCED_ROOT)
+    fun navigateToAdvSettings() = navController.navigate(SETTINGS.ADVANCED_ROOT)
+
+    fun goAdvSettingsRoot() {
+        if (isUnlocked || lockMethod == LockMethod.NONE) {
+            navigateToAdvSettings()
+            return
+        }
+        when (lockMethod) {
+            LockMethod.PIN -> {
+                showPinDialog = true
+            }
+            LockMethod.BIOMETRIC -> {
+                val activity = ctx as? FragmentActivity
+                if (activity != null && SecurityHelper.isBiometricAvailable(ctx)) {
+                    SecurityHelper.showBiometricPrompt(
+                        activity = activity,
+                        onSuccess = {
+                            isUnlocked = true
+                            navigateToAdvSettings()
+                        },
+                        onError = { msg ->
+                            ctx.showToast(ctx.getString(R.string.authentication_error, msg))
+                        },
+                        onFailed = {
+                            ctx.showToast(ctx.getString(R.string.authentication_failed))
+                        }
+                    )
+                } else {
+                    ctx.showToast(ctx.getString(R.string.biometric_not_available))
+                }
+            }
+            LockMethod.DEVICE_CREDENTIALS -> {
+                val activity = ctx as? FragmentActivity
+                if (activity != null && SecurityHelper.isDeviceCredentialAvailable(ctx)) {
+                    SecurityHelper.showDeviceCredentialPrompt(
+                        activity = activity,
+                        onSuccess = {
+                            isUnlocked = true
+                            navigateToAdvSettings()
+                        },
+                        onError = { msg ->
+                            ctx.showToast(ctx.getString(R.string.authentication_error, msg))
+                        },
+                        onFailed = {
+                            ctx.showToast(ctx.getString(R.string.authentication_failed))
+                        }
+                    )
+                } else {
+                    ctx.showToast(ctx.getString(R.string.device_credentials_not_available))
+                }
+            }
+            LockMethod.NONE -> navigateToAdvSettings()
+        }
+    }
     fun goAppearance() = navController.navigate(SETTINGS.APPEARANCE)
     fun goDebug() = navController.navigate(SETTINGS.DEBUG)
     fun goWellbeing() = navController.navigate(SETTINGS.WELLBEING)
@@ -134,6 +210,23 @@ fun SettingsNavHost(
             MaterialTheme.colorScheme.background
         }
 
+    // ── PIN unlock dialog ──
+    if (showPinDialog) {
+        PinUnlockDialog(
+            onDismiss = { showPinDialog = false; pinError = null },
+            onPinEntered = { enteredPin ->
+                if (SecurityHelper.verifyPin(enteredPin, pinHash)) {
+                    isUnlocked = true
+                    showPinDialog = false
+                    pinError = null
+                    navigateToAdvSettings()
+                } else {
+                    pinError = ctx.getString(R.string.wrong_pin)
+                }
+            },
+            errorMessage = pinError
+        )
+    }
 
     Scaffold(
         contentWindowInsets = WindowInsets(),

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -16,6 +16,7 @@ uiGraphics = "1.10.0"
 foundationLayout = "1.10.0"
 datastore = "1.2.0"
 appcompat = "1.7.1"
+biometric = "1.1.0"
 glanceAppwidget = "1.1.1"
 junit = "4.13.2"
 junitVersion = "1.3.0"
@@ -46,6 +47,7 @@ material = { module = "com.google.android.material:material", version.ref = "mat
 material3 = { module = "androidx.compose.material3:material3" }
 reorderable = { group = "org.burnoutcrew.composereorderable", name = "reorderable", version.ref = "reorderable" }
 androidx-appcompat = { group = "androidx.appcompat", name = "appcompat", version.ref = "appcompat" }
+androidx-biometric = { group = "androidx.biometric", name = "biometric", version.ref = "biometric" }
 androidx-glance-appwidget = { group = "androidx.glance", name = "glance-appwidget", version.ref = "glanceAppwidget" }
 junit = { group = "junit", name = "junit", version.ref = "junit" }
 androidx-junit = { group = "androidx.test.ext", name = "junit", version.ref = "junitVersion" }


### PR DESCRIPTION
## Summary

Implements settings lock protection for Dragon Launcher (#81).

### Features
- **PIN Code**: Set a 4+ digit PIN to protect access to advanced settings
- **Biometric (Fingerprint)**: Use device fingerprint to unlock settings
- **Device Credentials**: Use Android pattern/PIN/password to unlock settings
- **Session-based unlock**: Once authenticated, settings stay accessible until you leave the settings screen

### Implementation Details
- `LockMethod` enum in `core/enumsui`
- `lockMethod` setting in `BehaviorSettingsStore` (backed up with settings)
- `lockPinHash` in `PrivateSettingsStore` (SHA-256, NOT backed up for security)
- Lock gate in `SettingsNavHost` intercepts navigation to advanced settings
- Lock method picker dialog in `AdvancedSettingsScreen`
- `PinDialogs.kt`: PIN unlock dialog + PIN setup dialog (enter + confirm)
- `SecurityHelper.kt`: PIN hashing, BiometricPrompt wrappers, availability checks
- Added `androidx.biometric:biometric:1.1.0` dependency

### UI Flow
1. User goes to Advanced Settings → Lock Settings section
2. Selects a lock method (None / PIN / Fingerprint / Device Credentials)
3. If PIN: enter + confirm PIN dialog
4. Next time accessing Advanced Settings: authentication is required
5. Once unlocked, stays unlocked for the session

### Test Plan
- Set PIN lock → leave settings → re-enter → verify PIN dialog appears
- Set biometric lock → verify fingerprint prompt appears
- Set device credentials → verify Android lock screen prompt appears
- Set to None → verify no prompt
- Wrong PIN → verify error message

Closes #81