### PR TITLE
feat: App drawer swipe point workspace selection (#144)

### DIFF
--- a/app/src/main/java/org/elnix/dragonlauncher/MainActivity.kt
+++ b/app/src/main/java/org/elnix/dragonlauncher/MainActivity.kt
@@ -340,7 +340,7 @@ class MainActivity : ComponentActivity(), WidgetHostProvider {
                             SwipePointSerializable(
                                 circleNumber = 0,
                                 angleDeg = 0.toDouble(),
-                                action = SwipeActionSerializable.OpenAppDrawer,
+                                action = SwipeActionSerializable.OpenAppDrawer(),
                                 id = UUID.randomUUID().toString()
                             ),
                             SwipePointSerializable(

--- a/core/common/src/main/java/org/elnix/dragonlauncher/common/serializables/SwipeJson.kt
+++ b/core/common/src/main/java/org/elnix/dragonlauncher/common/serializables/SwipeJson.kt
@@ -60,7 +60,7 @@ sealed class SwipeActionSerializable {
     ) : SwipeActionSerializable()
     object NotificationShade : SwipeActionSerializable()
     object ControlPanel : SwipeActionSerializable()
-    object OpenAppDrawer : SwipeActionSerializable()
+    data class OpenAppDrawer(val workspaceId: String? = null) : SwipeActionSerializable()
     object  OpenDragonLauncherSettings: SwipeActionSerializable()
     object Lock: SwipeActionSerializable()
     object ReloadApps: SwipeActionSerializable()
@@ -123,7 +123,12 @@ class SwipeActionAdapter : JsonSerializer<SwipeActionSerializable>, JsonDeserial
             // Those with only the name as param
             is SwipeActionSerializable.NotificationShade -> { obj.addProperty("type", "NotificationShade") }
             is SwipeActionSerializable.ControlPanel -> { obj.addProperty("type", "ControlPanel") }
-            is SwipeActionSerializable.OpenAppDrawer -> { obj.addProperty("type", "OpenAppDrawer") }
+            is SwipeActionSerializable.OpenAppDrawer -> {
+                obj.addProperty("type", "OpenAppDrawer")
+                if (src.workspaceId != null) {
+                    obj.addProperty("workspaceId", src.workspaceId)
+                }
+            }
             is SwipeActionSerializable.OpenDragonLauncherSettings -> { obj.addProperty("type", "OpenDragonLauncherSettings") }
             is SwipeActionSerializable.Lock -> { obj.addProperty("type", "Lock") }
             is SwipeActionSerializable.ReloadApps -> { obj.addProperty("type", "ReloadApps") }
@@ -150,7 +155,9 @@ class SwipeActionAdapter : JsonSerializer<SwipeActionSerializable>, JsonDeserial
             )
             "NotificationShade" -> SwipeActionSerializable.NotificationShade
             "ControlPanel" -> SwipeActionSerializable.ControlPanel
-            "OpenAppDrawer" -> SwipeActionSerializable.OpenAppDrawer
+            "OpenAppDrawer" -> SwipeActionSerializable.OpenAppDrawer(
+                obj.get("workspaceId")?.asString
+            )
             "OpenDragonLauncherSettings" -> SwipeActionSerializable.OpenDragonLauncherSettings
             "Lock" -> SwipeActionSerializable.Lock
             "ReloadApps" -> SwipeActionSerializable.ReloadApps

--- a/core/common/src/main/java/org/elnix/dragonlauncher/common/utils/Constants.kt
+++ b/core/common/src/main/java/org/elnix/dragonlauncher/common/utils/Constants.kt
@@ -92,7 +92,7 @@ val defaultChoosableActions = listOf(
     SwipeActionSerializable.OpenFile(""),
     SwipeActionSerializable.NotificationShade,
     SwipeActionSerializable.ControlPanel,
-    SwipeActionSerializable.OpenAppDrawer,
+    SwipeActionSerializable.OpenAppDrawer(),
     SwipeActionSerializable.Lock,
     SwipeActionSerializable.ReloadApps,
     SwipeActionSerializable.OpenRecentApps,

--- a/core/common/src/main/java/org/elnix/dragonlauncher/common/utils/ImageUtils.kt
+++ b/core/common/src/main/java/org/elnix/dragonlauncher/common/utils/ImageUtils.kt
@@ -281,7 +281,7 @@ object ImageUtils {
             SwipeActionSerializable.ControlPanel ->
                 loadDrawableResAsBitmap(ctx, R.drawable.ic_action_grid, width, height)
 
-            SwipeActionSerializable.OpenAppDrawer ->
+            is SwipeActionSerializable.OpenAppDrawer ->
                 loadDrawableResAsBitmap(ctx, R.drawable.ic_action_drawer, width, height)
 
             SwipeActionSerializable.OpenDragonLauncherSettings ->

--- a/core/ui/src/main/java/org/elnix/dragonlauncher/ui/MainAppUi.kt
+++ b/core/ui/src/main/java/org/elnix/dragonlauncher/ui/MainAppUi.kt
@@ -269,7 +269,12 @@ fun MainAppUi(
                     floatingAppsViewModel = floatingAppsViewModel,
                     appLifecycleViewModel = appLifecycleViewModel,
                     widgetHostProvider = widgetHostProvider,
-                    onAppDrawer = { goDrawer() },
+                    onAppDrawer = { workspaceId ->
+                        if (workspaceId != null) {
+                            appsViewModel.selectWorkspace(workspaceId)
+                        }
+                        goDrawer()
+                    },
                     onGoWelcome = { goWelcome() },
                     onLongPress3Sec = { goSettingsRoot() }
                 )

--- a/core/ui/src/main/java/org/elnix/dragonlauncher/ui/MainScreen.kt
+++ b/core/ui/src/main/java/org/elnix/dragonlauncher/ui/MainScreen.kt
@@ -84,7 +84,7 @@ fun MainScreen(
     floatingAppsViewModel: FloatingAppsViewModel,
     appLifecycleViewModel: AppLifecycleViewModel,
     widgetHostProvider: WidgetHostProvider,
-    onAppDrawer: () -> Unit,
+    onAppDrawer: (workspaceId: String?) -> Unit,
     onGoWelcome: () -> Unit,
     onLongPress3Sec: () -> Unit
 ) {

--- a/core/ui/src/main/java/org/elnix/dragonlauncher/ui/actions/actionColors.kt
+++ b/core/ui/src/main/java/org/elnix/dragonlauncher/ui/actions/actionColors.kt
@@ -15,7 +15,7 @@ fun actionColor(
             is SwipeActionSerializable.OpenUrl -> extra.openUrl
             SwipeActionSerializable.NotificationShade -> extra.notificationShade
             SwipeActionSerializable.ControlPanel -> extra.controlPanel
-            SwipeActionSerializable.OpenAppDrawer -> extra.openAppDrawer
+            is SwipeActionSerializable.OpenAppDrawer -> extra.openAppDrawer
             SwipeActionSerializable.OpenDragonLauncherSettings -> extra.launcherSettings
             SwipeActionSerializable.Lock -> extra.lock
             is SwipeActionSerializable.OpenFile -> extra.openFile

--- a/core/ui/src/main/java/org/elnix/dragonlauncher/ui/actions/actionLabel.kt
+++ b/core/ui/src/main/java/org/elnix/dragonlauncher/ui/actions/actionLabel.kt
@@ -66,7 +66,7 @@ fun actionLabel(
 
             SwipeActionSerializable.ControlPanel -> stringResource(R.string.control_panel)
 
-            SwipeActionSerializable.OpenAppDrawer -> stringResource(R.string.app_drawer)
+            is SwipeActionSerializable.OpenAppDrawer -> stringResource(R.string.app_drawer)
 
             SwipeActionSerializable.OpenDragonLauncherSettings -> stringResource(R.string.dragon_launcher_settings)
 

--- a/core/ui/src/main/java/org/elnix/dragonlauncher/ui/actions/launchSwipeAction.kt
+++ b/core/ui/src/main/java/org/elnix/dragonlauncher/ui/actions/launchSwipeAction.kt
@@ -40,7 +40,7 @@ fun launchSwipeAction(
     onReloadApps: (() -> Unit)? = null,
     onReselectFile: (() -> Unit)? = null,
     onAppSettings: (() -> Unit)? = null,
-    onAppDrawer: (() -> Unit)? = null,
+    onAppDrawer: ((workspaceId: String?) -> Unit)? = null,
     onParentNest: (() -> Unit)? = null,
     onOpenNestCircle: ((nestId: Int) -> Unit)? = null,
 ) {
@@ -97,8 +97,8 @@ fun launchSwipeAction(
             else expandQuickActionsDrawer(ctx)
         }
 
-        SwipeActionSerializable.OpenAppDrawer -> {
-            onAppDrawer?.invoke()
+        is SwipeActionSerializable.OpenAppDrawer -> {
+            onAppDrawer?.invoke(action.workspaceId)
         }
 
         SwipeActionSerializable.OpenDragonLauncherSettings -> onAppSettings?.invoke()

--- a/core/ui/src/main/java/org/elnix/dragonlauncher/ui/dialogs/AddPointDialog.kt
+++ b/core/ui/src/main/java/org/elnix/dragonlauncher/ui/dialogs/AddPointDialog.kt
@@ -65,6 +65,9 @@ fun AddPointDialog(
     var showUrlInput by remember { mutableStateOf(false) }
     var showFilePicker by remember { mutableStateOf(false) }
     var showNestPicker by remember { mutableStateOf(false) }
+    var showWorkspacePicker by remember { mutableStateOf(false) }
+
+    val workspaces by appsViewModel.enabledState.collectAsState()
 
 
     val icons by appsViewModel.icons.collectAsState()
@@ -131,12 +134,22 @@ fun AddPointDialog(
                             Spacer(Modifier.height(8.dp))
                         }
 
-                        // Open File picker to choose a file
+                        // Open Circle Nest → requires nest picker
                         is SwipeActionSerializable.OpenCircleNest -> {
                             AddPointColumn(
                                 action = action,
                                 icons = icons,
                                 onSelected = { showNestPicker = true }
+                            )
+                            Spacer(Modifier.height(8.dp))
+                        }
+
+                        // Open App Drawer → workspace picker
+                        is SwipeActionSerializable.OpenAppDrawer -> {
+                            AddPointColumn(
+                                action = action,
+                                icons = icons,
+                                onSelected = { showWorkspacePicker = true }
                             )
                             Spacer(Modifier.height(8.dp))
                         }
@@ -242,6 +255,73 @@ fun AddPointDialog(
                 onActionSelected(SwipeActionSerializable.OpenCircleNest(it.id))
                 showNestPicker = false
             }
+        )
+    }
+
+    if (showWorkspacePicker) {
+        val availableWorkspaces = workspaces.workspaces
+        AlertDialog(
+            onDismissRequest = { showWorkspacePicker = false },
+            confirmButton = {},
+            title = { Text(stringResource(R.string.select_default_workspace)) },
+            text = {
+                Column(
+                    verticalArrangement = Arrangement.spacedBy(5.dp)
+                ) {
+                    Text(
+                        text = stringResource(R.string.select_workspace_hint),
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurface.copy(0.7f)
+                    )
+                    Spacer(Modifier.height(8.dp))
+
+                    // "Default" option (no specific workspace)
+                    Column(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .clip(DragonShape)
+                            .background(MaterialTheme.colorScheme.surfaceVariant)
+                            .clickable {
+                                onActionSelected(SwipeActionSerializable.OpenAppDrawer())
+                                showWorkspacePicker = false
+                            }
+                            .padding(12.dp),
+                        horizontalAlignment = Alignment.CenterHorizontally
+                    ) {
+                        Text(
+                            text = stringResource(R.string.lock_none),
+                            style = MaterialTheme.typography.bodyLarge,
+                            color = MaterialTheme.colorScheme.onSurface
+                        )
+                    }
+
+                    // Specific workspaces
+                    availableWorkspaces.forEach { workspace ->
+                        Column(
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .clip(DragonShape)
+                                .background(MaterialTheme.colorScheme.surface)
+                                .clickable {
+                                    onActionSelected(
+                                        SwipeActionSerializable.OpenAppDrawer(workspace.id)
+                                    )
+                                    showWorkspacePicker = false
+                                }
+                                .padding(12.dp),
+                            horizontalAlignment = Alignment.CenterHorizontally
+                        ) {
+                            Text(
+                                text = workspace.name,
+                                style = MaterialTheme.typography.bodyLarge,
+                                color = MaterialTheme.colorScheme.onSurface
+                            )
+                        }
+                    }
+                }
+            },
+            containerColor = MaterialTheme.colorScheme.surface,
+            shape = DragonShape
         )
     }
 }

--- a/core/ui/src/main/java/org/elnix/dragonlauncher/ui/settings/customization/FloatingAppsTab.kt
+++ b/core/ui/src/main/java/org/elnix/dragonlauncher/ui/settings/customization/FloatingAppsTab.kt
@@ -385,7 +385,7 @@ fun FloatingAppsTab(
                 SwipeActionSerializable.OpenFile(""),
                 SwipeActionSerializable.NotificationShade,
                 SwipeActionSerializable.ControlPanel,
-                SwipeActionSerializable.OpenAppDrawer,
+                SwipeActionSerializable.OpenAppDrawer(),
                 SwipeActionSerializable.Lock,
                 SwipeActionSerializable.ReloadApps,
                 SwipeActionSerializable.OpenRecentApps,


### PR DESCRIPTION
## Summary

Allows users to choose which workspace opens by default when creating a swipe point that opens the app drawer (#144).

### Changes
- **`SwipeActionSerializable.OpenAppDrawer`**: Converted from `object` to `data class` with optional `workspaceId: String?` parameter
- **`SwipeActionAdapter`**: Updated to serialize/deserialize the new `workspaceId` field. `null` = use current default (backward compatible with existing saved data)
- **`AddPointDialog`**: When selecting "App Drawer" action, a workspace picker dialog now appears letting the user choose a specific workspace or "Default"
- **`launchSwipeAction`**: `onAppDrawer` callback now accepts `workspaceId: String?`
- **`MainScreen`** + **`MainAppUi`**: Thread the workspace ID through the callback chain. Before navigating to the drawer, `appsViewModel.selectWorkspace(id)` is called to set the correct pager page
- **Pattern match updates**: All `when` branches across the codebase updated for the new data class syntax

### How It Works
1. User creates a new swipe point → picks "App Drawer"
2. A workspace picker dialog appears showing all enabled workspaces
3. Selecting a workspace creates `OpenAppDrawer(workspaceId = "..."+)`
4. When the point is activated, the drawer opens directly on that workspace page
5. Selecting "Default" creates `OpenAppDrawer(workspaceId = null)` — the drawer opens on whatever workspace was last selected

### Backward Compatibility
- Old saved `{"type": "OpenAppDrawer"}` JSON is deserialized as `OpenAppDrawer(workspaceId = null)` — no migration needed

Closes #144