### PR TITLE
feat: Recently used apps section in app drawer (#145)

### DIFF
--- a/core/models/src/main/java/org/elnix/dragonlauncher/models/AppsViewModel.kt
+++ b/core/models/src/main/java/org/elnix/dragonlauncher/models/AppsViewModel.kt
@@ -53,6 +53,7 @@ import org.elnix.dragonlauncher.common.utils.ImageUtils.resolveCustomIconBitmap
 import org.elnix.dragonlauncher.common.utils.PackageManagerCompat
 import org.elnix.dragonlauncher.common.utils.TAG
 import org.elnix.dragonlauncher.settings.stores.AppsSettingsStore
+import org.elnix.dragonlauncher.settings.stores.DrawerSettingsStore
 import org.elnix.dragonlauncher.settings.stores.SwipeSettingsStore
 import org.elnix.dragonlauncher.settings.stores.UiSettingsStore
 import org.elnix.dragonlauncher.settings.stores.WorkspaceSettingsStore
@@ -141,6 +142,10 @@ class AppsViewModel(
     private val _selectedWorkspaceId = MutableStateFlow("user")
     val selectedWorkspaceId: StateFlow<String> = _selectedWorkspaceId.asStateFlow()
 
+    /* ───────────── Recently Used Apps ───────────── */
+    private val _recentlyUsedPackages = MutableStateFlow<List<String>>(emptyList())
+    val recentlyUsedPackages: StateFlow<List<String>> = _recentlyUsedPackages.asStateFlow()
+
 
     init {
         scope.launch {
@@ -154,6 +159,7 @@ class AppsViewModel(
     suspend fun loadAll() {
         loadWorkspaces()
         loadDefaultPoint()
+        loadRecentlyUsedApps()
         val savedPackTint = UiSettingsStore.iconPackTint.get(ctx)
         savedPackTint?.let { tint ->
             _packTint.value = tint.toArgb()
@@ -705,6 +711,49 @@ class AppsViewModel(
 
     fun selectWorkspace(id: String) {
         _selectedWorkspaceId.value = id
+    }
+
+    /* ───────────── Recently Used Apps ───────────── */
+
+    private suspend fun loadRecentlyUsedApps() {
+        val json = DrawerSettingsStore.recentlyUsedPackages.get(ctx)
+        if (!json.isNullOrEmpty()) {
+            try {
+                val type = object : TypeToken<List<String>>() {}.type
+                _recentlyUsedPackages.value = gson.fromJson(json, type) ?: emptyList()
+            } catch (_: Exception) {
+                _recentlyUsedPackages.value = emptyList()
+            }
+        }
+    }
+
+    /**
+     * Record a package as recently used.
+     * Moves it to the front if already present, trims the list to a reasonable max.
+     */
+    fun addRecentlyUsedApp(packageName: String) {
+        val maxStored = 30 // store more than display, user can raise the count later
+        val current = _recentlyUsedPackages.value.toMutableList()
+        current.remove(packageName)
+        current.add(0, packageName)
+        val trimmed = current.take(maxStored)
+        _recentlyUsedPackages.value = trimmed
+        scope.launch {
+            DrawerSettingsStore.recentlyUsedPackages.set(ctx, gson.toJson(trimmed))
+        }
+    }
+
+    /**
+     * Returns the recently used [AppModel]s, resolved from the current app list.
+     * @param count max number of recent apps to return
+     */
+    fun getRecentApps(count: Int): StateFlow<List<AppModel>> {
+        return _recentlyUsedPackages.map { packages ->
+            val allApps = _apps.value.associateBy { it.packageName }
+            packages
+                .take(count)
+                .mapNotNull { pkg -> allApps[pkg] }
+        }.stateIn(scope, SharingStarted.Eagerly, emptyList())
     }
 
 

--- a/core/settings/src/main/java/org/elnix/dragonlauncher/settings/stores/DrawerSettingsStore.kt
+++ b/core/settings/src/main/java/org/elnix/dragonlauncher/settings/stores/DrawerSettingsStore.kt
@@ -146,6 +146,27 @@ object DrawerSettingsStore : MapSettingsStore() {
         default = 96
     )
 
+    /* ───────────── Recently Used Apps ───────────── */
+
+    val showRecentlyUsedApps = Settings.boolean(
+        key = "showRecentlyUsedApps",
+        dataStoreName = dataStoreName,
+        default = false
+    )
+
+    val recentlyUsedAppsCount = Settings.int(
+        key = "recentlyUsedAppsCount",
+        dataStoreName = dataStoreName,
+        default = 5
+    )
+
+    /** JSON-encoded ordered list of recently-used package names (most recent first). */
+    val recentlyUsedPackages = Settings.string(
+        key = "recentlyUsedPackages",
+        dataStoreName = dataStoreName,
+        default = ""
+    )
+
 
     override val ALL: List<BaseSettingObject<*,*>>
         get() = listOf(
@@ -165,6 +186,9 @@ object DrawerSettingsStore : MapSettingsStore() {
             drawerHomeAction,
             scrollDownDrawerAction,
             scrollUpDrawerAction,
-            iconsShape
+            iconsShape,
+            showRecentlyUsedApps,
+            recentlyUsedAppsCount,
+            recentlyUsedPackages
         )
 }

--- a/core/ui/src/main/java/org/elnix/dragonlauncher/ui/settings/customization/DrawerTab.kt
+++ b/core/ui/src/main/java/org/elnix/dragonlauncher/ui/settings/customization/DrawerTab.kt
@@ -143,6 +143,26 @@ fun DrawerTab(
             )
         }
 
+        /* ───────────── Recently Used Apps ───────────── */
+
+        item { TextDivider(stringResource(R.string.recently_used_apps)) }
+
+        item {
+            SettingsSwitchRow(
+                setting = DrawerSettingsStore.showRecentlyUsedApps,
+                title = stringResource(R.string.show_recently_used_apps),
+                description = stringResource(R.string.show_recently_used_apps_desc),
+            )
+        }
+
+        item {
+            SettingsSlider(
+                setting = DrawerSettingsStore.recentlyUsedAppsCount,
+                title = stringResource(R.string.recently_used_apps_count),
+                valueRange = 1..20
+            )
+        }
+
 
 //        item {
 //            SwitchRow(


### PR DESCRIPTION
## Summary

Adds a "Recently Used Apps" section at the top of the app drawer, showing the most recently launched apps as a horizontally scrollable row (#145).

### Changes

#### Settings (`DrawerSettingsStore`)
- **`showRecentlyUsedApps`** (boolean, default `false`) — toggle to show/hide the section
- **`recentlyUsedAppsCount`** (int, default `5`) — how many recent apps to display
- **`recentlyUsedPackages`** (string, default `""`) — JSON-encoded ordered list of recently-used package names, persisted across sessions

#### ViewModel (`AppsViewModel`)
- **`_recentlyUsedPackages`** — `StateFlow<List<String>>` holding the ordered recent package names
- **`addRecentlyUsedApp(packageName)`** — pushes an app to the front of the list, deduplicates, trims to 30 entries, and persists via DataStore
- **`getRecentApps(count)`** — returns a `StateFlow<List<AppModel>>` resolved from the current installed apps
- **`loadRecentlyUsedApps()`** — loads persisted data on init

#### UI (`AppDrawerScreen`)
- Inside `HorizontalPager`, a `TextDivider` header + `LazyRow` of `RecentAppItem` composables appears above the main `AppGrid`
- Only shown when: setting is enabled, search query is blank, and there are recent apps available
- Each item shows the app icon (with shape) and label, supports click to launch and long-press for the standard context menu
- App launches are automatically tracked in `launchApp()`

#### Settings UI (`DrawerTab`)
- New "Recently Used Apps" section with a toggle switch and a count slider (1–20)

### How It Works
1. User enables "Show recently used apps" in Drawer settings
2. Every app launched from the drawer is recorded (most recent first, max 30 stored)
3. The drawer shows the N most recent apps (configurable) as an icon row above the grid
4. The list persists across app restarts via DataStore

Closes #145