### PR TITLE
Fixed points icons rendering behind the circles, now erases correctly…

### DIFF
--- a/core/ui/src/main/java/org/elnix/dragonlauncher/ui/helpers/nests/actionInCircle.kt
+++ b/core/ui/src/main/java/org/elnix/dragonlauncher/ui/helpers/nests/actionInCircle.kt
@@ -56,7 +56,7 @@ fun DrawScope.actionsInCircle(
     val px = center.x
     val py = center.y
 
-    val size =( point.size ?: defaultPoint.size ?: defaultSwipePointsValues.size!!).coerceAtLeast(1)
+    val size = (point.size ?: defaultPoint.size ?: defaultSwipePointsValues.size!!).coerceAtLeast(1)
     val innerPadding =
         point.innerPadding ?: defaultPoint.innerPadding ?: defaultSwipePointsValues.innerPadding!!
 
@@ -86,8 +86,6 @@ fun DrawScope.actionsInCircle(
     } ?: IconShape.Circle
 
 
-
-
     val borderShape = resolveShape(borderIconShape)
 
     val backgroundColor = if (selected) {
@@ -103,11 +101,36 @@ fun DrawScope.actionsInCircle(
 
     val shape = resolveShape(point.customIcon?.shape ?: iconShape)
 
-    // if in the settings, set the alpha
-//    if (preventBgErasing) backgroundColor = backgroundColor.copy(1f)
 
     if (action !is SwipeActionSerializable.OpenCircleNest) {
 
+
+
+        /* ───────────── Erases the circle in the point ───────────── */
+
+        // if no background color provided, erases the background
+        val eraseBg = backgroundColor == Color.Transparent && !preventBgErasing
+
+        // Erases the color, instead of putting it, that lets the wallpaper pass trough
+        drawCircle(
+            color = Color.Transparent,
+            radius = borderRadii,
+            center = center,
+            blendMode = BlendMode.Clear
+        )
+
+        // If requested to not erase the bg, draw it (this avoid the more tinted bg when using a half transparent bg color
+        if (!eraseBg) {
+            drawCircle(
+                color = backgroundColor,
+                radius = borderRadii,
+                center = center
+            )
+        }
+
+
+
+        /* ───────────── Draws the border (custom shape) ───────────── */
 
         val iconSizeF = borderRadii * 2f
 
@@ -124,32 +147,13 @@ fun DrawScope.actionsInCircle(
             is Outline.Generic -> outline.path
         }
 
-        // if no background color provided, erases the background
-        val eraseBg = backgroundColor == Color.Transparent && !preventBgErasing
-
         // Move drawing to icon position
         translate(
             left = center.x - borderRadii,
             top = center.y - borderRadii
         ) {
 
-
             if (borderStroke > 0f) {
-                if (eraseBg) {
-                    // Erases the color, instead of putting it, that lets the wallpaper pass trough
-                    drawPath(
-                        path = path,
-                        color = borderColor,
-                        style = Stroke(width = borderStroke),
-                        blendMode = BlendMode.Clear
-                    )
-                } else {
-                    drawPath(
-                        path = path,
-                        color = backgroundColor,
-                        style = Stroke(width = borderStroke)
-                    )
-                }
                 if (borderColor.alpha != 0f) {
 
                     drawPath(

--- a/core/ui/src/main/java/org/elnix/dragonlauncher/ui/helpers/nests/circlesSettingsOverlay.kt
+++ b/core/ui/src/main/java/org/elnix/dragonlauncher/ui/helpers/nests/circlesSettingsOverlay.kt
@@ -2,6 +2,7 @@ package org.elnix.dragonlauncher.ui.helpers.nests
 
 import android.content.Context
 import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.graphics.BlendMode
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.ImageBitmap
 import androidx.compose.ui.graphics.drawscope.DrawScope
@@ -35,6 +36,31 @@ fun DrawScope.circlesSettingsOverlay(
     selectedAll: Boolean = false,
     preventBgErasing: Boolean = false
 ) {
+
+    // 0. Erases the inner circle
+    /* ───────────── Erases the circle in the point ───────────── */
+
+    // if no background color provided, erases the background
+    val eraseBg = backgroundColor == Color.Transparent && !preventBgErasing
+    val maxCircleSize = circles.maxBy { it.radius }
+
+    // Erases the color, instead of putting it, that lets the wallpaper pass trough
+    drawCircle(
+        color = Color.Transparent,
+        radius = maxCircleSize.radius,
+        center = center,
+        blendMode = BlendMode.Clear
+    )
+
+    // If requested to not erase the bg, draw it (this avoid the more tinted bg when using a half transparent bg color
+    if (!eraseBg) {
+        drawCircle(
+            color = backgroundColor,
+            radius = maxCircleSize.radius,
+            center = center
+        )
+    }
+
     // 1. Draw all circles
     circles.forEach { circle ->
         if (showCircle) {


### PR DESCRIPTION
… the circle behind the points and sub nests for cleaner integration

closes #169 