### PR TITLE
Disable lint checks for release builds in Gradle and workflows

### DIFF
--- a/.github/workflows/pre-release_on-push.yml
+++ b/.github/workflows/pre-release_on-push.yml
@@ -63,7 +63,7 @@ jobs:
         with:
           timeout_minutes: 15
           max_attempts: 3
-          command: ./gradlew lintBetaRelease assembleBetaRelease assembleBetaUnminifiedRelease assembleBetaDebuggableRelease assembleBetaDebug --parallel --no-daemon --build-cache
+          command: ./gradlew assembleBetaRelease assembleBetaUnminifiedRelease assembleBetaDebuggableRelease assembleBetaDebug --parallel --no-daemon --build-cache -x lint
 
       - name: Rename APKs with version
         run: |

--- a/.github/workflows/release-on-tag.yml
+++ b/.github/workflows/release-on-tag.yml
@@ -52,7 +52,7 @@ jobs:
           } >> $GITHUB_ENV
 
       - name: Build Release APK
-        run: ./gradlew assembleStableRelease assembleBetaDebuggableRelease --parallel --no-daemon --build-cache
+        run: ./gradlew assembleStableRelease assembleBetaDebuggableRelease --parallel --no-daemon --build-cache -x lint
 
       - name: Rename APK
         run: |

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -38,6 +38,11 @@ extensions.configure<ApplicationExtension> {
         versionCode = (property("VERSION_CODE") as String).toInt()
     }
 
+    lint {
+        checkReleaseBuilds = false
+        abortOnError = false
+    }
+
 
     flavorDimensions += "channel"
     productFlavors {


### PR DESCRIPTION
This pull request makes adjustments to the build and linting process for release and pre-release APKs, aiming to speed up CI workflows and reduce build failures due to lint errors. The most important changes are grouped below:

Build process adjustments:

* Disabled lint checks during the release and pre-release APK build steps in `.github/workflows/pre-release_on-push.yml` and `.github/workflows/release-on-tag.yml` by adding the `-x lint` flag to the `./gradlew` command. [[1]](diffhunk://#diff-7d6351d6ef4b7eebb2916e76c855d70780e7ebe901ca0475a944ee30f98e2ac9L66-R66) [[2]](diffhunk://#diff-906e630a07a825c223f35d1c346b423dc8278cf379479ad687528f1a6e943b7aL55-R55)

Lint configuration updates:

* Updated the `lint` block in `app/build.gradle.kts` to turn off lint checks for release builds and prevent build failures caused by lint errors by setting `checkReleaseBuilds = false` and `abortOnError = false`.