### PR TITLE
fast live nest launch + default root nest

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,0 +1,54 @@
+# Changes
+
+## Feature: Open root nest each time
+
+A global toggle that resets the live nest navigation back to the root nest on every new gesture, so the user always starts from the root regardless of which nest they were in before.
+
+### Files
+
+#### Settings
+
+- **`core/settings/.../stores/BehaviorSettingsStore.kt`**
+  — Added `openRootNestEachTime` boolean setting (default `false`, key `"openRootNestEachTime"`).
+
+- **`core/ui/.../settings/customization/BehaviorTab.kt`**
+  — Added `SettingsSwitchRow` for the toggle.
+
+- **`core/common/.../res/values/strings.xml`**
+  — Added `open_root_nest_each_time` and `open_root_nest_each_time_desc` strings.
+
+#### Functionality
+
+- **`core/ui/.../ui/MainScreen.kt`**
+  — On finger-down (`start = down.position`), calls `nestNavigation.clearStack()` when the setting is enabled.
+  
+  — Removed `nestId` from the `pointerInput(Unit, nestId)` key. `nestId` changed mid-gesture when `clearStack()` ran, which cancelled and restarted the pointer scope — the fresh scope saw a MOVE event (not DOWN) and silently dropped the gesture. The handler reads all reactive state fresh per iteration, so the key was unnecessary.
+
+
+---
+
+## Feature: Fast activation (sharp-turn live nest entry)
+
+A live-nest toggle. When enabled, a sharp change in the user's drag direction while hovering the live nest point immediately opens the nested nest, without waiting for the full hold delay.
+
+### Files
+
+#### Settings
+
+- **`core/ui/.../dialogs/EditPointSheet.kt`**
+  — Added a `SwitchRow` for `fastActivation` under the live nest settings section (after the "Snaps to finger position" toggle).
+
+- **`core/common/.../serializables/SwipePointSerializable.kt`**
+  — Added `fastActivation: Boolean? = null` field (default `false` in `defaultSwipePointsValues`).
+
+- **`core/common/.../res/values/strings.xml`**
+  — Strings `fast_activation` / `fast_activation_desc` kept; semantics unchanged (the description already described per-point behavior).
+
+#### Functionality
+
+- **`core/ui/.../remembers/rememberLiveNestController.kt`**
+  — **Position tracking:** Uses a `SideEffect` to sync `current` into a reactive `currentSnap` state, then a `LaunchedEffect(Unit)` polling loop at 16 ms reads `currentSnap`, applies the jitter filter, fills the buffer, and bumps `angleVersion`.
+  — **`hasSharpAngle` derived state:** Reads `angleVersion`, then computes the turn angle from the two buffer halves and the stroke displacement. Returns `true` only when both exceed their thresholds.
+  — **Hold timer:** Resolves `pointFastActivation` from the per-point setting (`currentPoint.fastActivation ?: defaultPoint.fastActivation ?: defaultSwipePointsValues.fastActivation!!`) and checks `hasSharpAngle.value` every 32 ms. If true, breaks the delay early and opens the nested nest.
+  — **Early version update:** Added `angleVersion++` after `recentPositions.clear()` (gesture end) so the derived state cache is invalidated immediately.
+

--- a/core/common/src/main/kotlin/org/elnix/dragonlauncher/common/serializables/SwipePointSerializable.kt
+++ b/core/common/src/main/kotlin/org/elnix/dragonlauncher/common/serializables/SwipePointSerializable.kt
@@ -180,6 +180,12 @@ data class SwipePointSerializable(
      */
     val liveNestSnapsToFingerPosition: Boolean? = null,
 
+    /**
+     * When enabled, a sharp angle in the user's drag while hovering this point
+     * immediately enters the nested nest instead of waiting for the hold delay.
+     */
+    val fastActivation: Boolean? = null,
+
     /*  ─────────────  Cycle Actions configuration  ─────────────  */
 
     /**
@@ -249,6 +255,7 @@ data class SwipePointSerializable(
             liveNestScale = 0.65f,
             liveNestGraceDistancePx = 50,
             liveNestSnapsToFingerPosition = true,
+            fastActivation = false,
             holdAndRunDelayMs = 500,
             cycleActionsLoopDelayMs = 500, // -1 = No loop
             cycleActionStageDefaultDelay = 500,

--- a/core/common/src/main/res/values/strings.xml
+++ b/core/common/src/main/res/values/strings.xml
@@ -930,6 +930,10 @@
     <string name="align_end">End</string>
     <string name="create_live_nest_by_default_desc">When creating a new point, if you choose OpenCircleNest, it\'ll create the according live nest automatically</string>
     <string name="create_live_nest_by_default">Create live nest by default</string>
+    <string name="open_root_nest_each_time">Open root nest each time</string>
+    <string name="open_root_nest_each_time_desc">When enabled, the root nest is always shown when opening the launcher, regardless of which nest you last entered.</string>
+    <string name="fast_activation">Fast activation</string>
+    <string name="fast_activation_desc">When enabled, a sharp angle in your drag immediately enters the nested nest instead of waiting for the hold delay.</string>
     <string name="welcome_screen">Welcome Screen</string>
     <string name="red">Red</string>
     <string name="green">Green</string>

--- a/core/settings/src/main/kotlin/org/elnix/dragonlauncher/settings/stores/BehaviorSettingsStore.kt
+++ b/core/settings/src/main/kotlin/org/elnix/dragonlauncher/settings/stores/BehaviorSettingsStore.kt
@@ -31,7 +31,8 @@ object BehaviorSettingsStore : MapSettingsStore() {
             this.alarmSound,
             this.vibrateOnError,
             this.offScreenTimeout,
-            this.createLiveNestByDefaultWhenCreatingOpenCircleNestPoint
+            this.createLiveNestByDefaultWhenCreatingOpenCircleNestPoint,
+            this.openRootNestEachTime
         )
 
     val backAction = Settings.swipeAction(
@@ -163,5 +164,11 @@ object BehaviorSettingsStore : MapSettingsStore() {
         key = "createLiveNestByDefaultWhenCreatingOpenCircleNestPoint",
         dataStoreName = UiSettingsStore.dataStoreName,
         default = true
+    )
+
+    val openRootNestEachTime = Settings.boolean(
+        key = "openRootNestEachTime",
+        dataStoreName = dataStoreName,
+        default = false
     )
 }

--- a/core/ui/main/src/main/kotlin/org/elnix/dragonlauncher/ui/MainScreen.kt
+++ b/core/ui/main/src/main/kotlin/org/elnix/dragonlauncher/ui/MainScreen.kt
@@ -99,6 +99,7 @@ fun MainScreen(
     val rotationPerSecond by HoldToActivateArcSettingsStore.rotationPerSecond.asState()
 
     val rgbLoading by UiSettingsStore.rgbLoading.asState()
+    val openRootNestEachTime by BehaviorSettingsStore.openRootNestEachTime.asState()
 
 
     var start by remember { mutableStateOf<Offset?>(null) }
@@ -205,7 +206,7 @@ fun MainScreen(
         modifier = Modifier
             .fillMaxSize()
             .background(Color.Transparent)
-            .pointerInput(Unit, nestId) {
+            .pointerInput(Unit) {
                 awaitPointerEventScope {
                     while (true) {
                         val event = awaitPointerEvent(PointerEventPass.Initial)
@@ -239,6 +240,10 @@ fun MainScreen(
 
                         start = down.position
                         current = down.position
+
+                        if (openRootNestEachTime) {
+                            nestNavigation.clearStack()
+                        }
 
                         val pointerId = down.id
 

--- a/core/ui/main/src/main/kotlin/org/elnix/dragonlauncher/ui/dialogs/EditPointSheet.kt
+++ b/core/ui/main/src/main/kotlin/org/elnix/dragonlauncher/ui/dialogs/EditPointSheet.kt
@@ -423,6 +423,18 @@ fun EditPointSheet(
                                         }
                                     }
 
+                                    SwitchRow(
+                                        state = editPoint.fastActivation ?: false,
+                                        title = stringResource(R.string.fast_activation),
+                                        description = stringResource(R.string.fast_activation_desc)
+                                    ) { on ->
+                                        editPoint = if (on) {
+                                            editPoint.copy(fastActivation = true)
+                                        } else {
+                                            editPoint.copy(fastActivation = null)
+                                        }
+                                    }
+
                                     val currentOpacity = (editPoint.liveNestMainNestOpacityPercent ?: defaultLiveNestMainNestOpacityPercent)
                                     SwitchRow(
                                         state = currentOpacity != -1,

--- a/core/ui/main/src/main/kotlin/org/elnix/dragonlauncher/ui/remembers/rememberLiveNestController.kt
+++ b/core/ui/main/src/main/kotlin/org/elnix/dragonlauncher/ui/remembers/rememberLiveNestController.kt
@@ -3,12 +3,17 @@ package org.elnix.dragonlauncher.ui.remembers
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.SideEffect
+import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableIntStateOf
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.geometry.Offset
 import kotlinx.coroutines.delay
+import kotlinx.coroutines.isActive
+import kotlin.math.acos
+import kotlin.math.sqrt
 import org.elnix.dragonlauncher.common.serializables.CircleNest
 import org.elnix.dragonlauncher.common.serializables.SwipePointSerializable
 import org.elnix.dragonlauncher.common.serializables.SwipePointSerializable.Companion.defaultSwipePointsValues
@@ -122,6 +127,70 @@ fun rememberLiveNestControllerStack(
     val activeLevelIndex = nestStack.indexOfLast { it.liveNestActive }
     val isAnyLiveNestActive = activeLevelIndex > 0
 
+    /* ─────────────  Fast activation: turn tracking  ───────────── */
+
+    val recentPositions = remember { mutableListOf<Offset>() }
+    var angleVersion by remember { mutableIntStateOf(0) }
+
+    var currentSnap by remember { mutableStateOf(current) }
+    SideEffect {
+        currentSnap = current
+    }
+
+    LaunchedEffect(Unit) {
+        while (isActive) {
+            val pos = currentSnap
+            if (pos != null) {
+                val last = recentPositions.lastOrNull()
+                if (last == null || sqrt(
+                        (pos.x - last.x) * (pos.x - last.x) +
+                                (pos.y - last.y) * (pos.y - last.y)
+                    ) >= 10f
+                ) {
+                    recentPositions.add(pos)
+                    if (recentPositions.size > 20) {
+                        repeat(recentPositions.size - 20) { recentPositions.removeFirst() }
+                    }
+                    angleVersion++
+                }
+            }
+            delay(16)
+        }
+    }
+
+    val hasSharpAngle = remember {
+        derivedStateOf {
+            angleVersion
+
+            val pts = recentPositions
+            val n = pts.size
+            if (n < 4) return@derivedStateOf false
+
+            val mid = n / 2
+            val v1x = pts[mid].x - pts[0].x
+            val v1y = pts[mid].y - pts[0].y
+            val v2x = pts.last().x - pts[mid].x
+            val v2y = pts.last().y - pts[mid].y
+
+            val mag1 = sqrt(v1x * v1x + v1y * v1y)
+            val mag2 = sqrt(v2x * v2x + v2y * v2y)
+            if (mag1 <= 10f || mag2 <= 10f) return@derivedStateOf false
+
+            val dot = v1x * v2x + v1y * v2y
+            val cosAngle = (dot / (mag1 * mag2)).coerceIn(-1f, 1f)
+            val turnAngle = acos(cosAngle) * 180f / kotlin.math.PI.toFloat()
+
+            val strokeLen = sqrt(
+                (pts.last().x - pts[0].x) * (pts.last().x - pts[0].x) +
+                        (pts.last().y - pts[0].y) * (pts.last().y - pts[0].y)
+            )
+
+			// Should the treshold angle be configurable? Probably
+			// Should the jitter threshold (minimum strokeLen) be configurable? Probably not?
+            turnAngle > 30f && strokeLen >= 80f
+        }
+    }
+
     val rootHit = remember(
         resetTrigger,
         isAnyLiveNestActive,
@@ -227,6 +296,8 @@ fun rememberLiveNestControllerStack(
             nestStack.forEach { level ->
                 level.liveNestCenter = null
             }
+            recentPositions.clear()
+            angleVersion++
         }
     }
 
@@ -274,7 +345,15 @@ fun rememberLiveNestControllerStack(
 
             val currentPointOffset = currentPoint.computePosition(previousLiveNestCircles, previousLiveNestCenter)
 
-            delay(delayMs)
+            val pointFastActivation = currentPoint.fastActivation ?: defaultPoint.fastActivation ?: defaultSwipePointsValues.fastActivation!!
+
+            val startTime = System.currentTimeMillis()
+            while (System.currentTimeMillis() - startTime < delayMs) {
+                if (pointFastActivation && hasSharpAngle.value) {
+                    break
+                }
+                delay(32)
+            }
 
 
             val snapToCenterPos = currentPoint.liveNestSnapsToFingerPosition ?: defaultPoint.liveNestSnapsToFingerPosition ?: defaultSwipePointsValues.liveNestSnapsToFingerPosition!!

--- a/core/ui/main/src/main/kotlin/org/elnix/dragonlauncher/ui/settings/customization/BehaviorTab.kt
+++ b/core/ui/main/src/main/kotlin/org/elnix/dragonlauncher/ui/settings/customization/BehaviorTab.kt
@@ -169,6 +169,12 @@ fun BehaviorTab(
             )
 
             SettingsSwitchRow(
+                setting = BehaviorSettingsStore.openRootNestEachTime,
+                title = stringResource(R.string.open_root_nest_each_time),
+                description = stringResource(R.string.open_root_nest_each_time_desc)
+            )
+
+            SettingsSwitchRow(
                 setting = BehaviorSettingsStore.useDifferentialLoadingForPrivateSpace,
                 title = stringResource(R.string.use_differential_loading_private_space),
                 description = stringResource(R.string.use_differential_loading_private_space_desc)


### PR DESCRIPTION
All the changes are detailed in CHANGES.md, but here is basically what I added:
 - A global toggle that resets the live nest navigation back to the root nest on every new gesture, so the user always starts from the root regardless of which nest they were in before.
 - A live-nest toggle. When enabled, a sharp change in the user's drag direction while hovering the live nest point immediately opens the nested nest, without waiting for the full hold delay.
