### PR TITLE
Save widgets before returning from widget settings screen

### DIFF
--- a/core/models/src/main/kotlin/org/elnix/dragonlauncher/models/WidgetsViewModel.kt
+++ b/core/models/src/main/kotlin/org/elnix/dragonlauncher/models/WidgetsViewModel.kt
@@ -67,9 +67,10 @@ public class WidgetsViewModel @Inject constructor(
     )
 
 
-    public fun save() {
+    public fun save(onSuccess: () -> Unit) {
         viewModelScope.launch {
             WidgetsSettingsStore.jsonSetting.set(application.applicationContext, WidgetsJson.encode(snapshotWidgets()))
+            onSuccess()
         }
     }
 

--- a/core/models/src/main/kotlin/org/elnix/dragonlauncher/models/WidgetsViewModel.kt
+++ b/core/models/src/main/kotlin/org/elnix/dragonlauncher/models/WidgetsViewModel.kt
@@ -67,10 +67,9 @@ public class WidgetsViewModel @Inject constructor(
     )
 
 
-    public fun save(onSuccess: () -> Unit) {
+    public fun save() {
         viewModelScope.launch {
             WidgetsSettingsStore.jsonSetting.set(application.applicationContext, WidgetsJson.encode(snapshotWidgets()))
-            onSuccess()
         }
     }
 

--- a/ui/main/src/main/kotlin/org/elnix/dragonlauncher/ui/settings/customization/WidgetsTab.kt
+++ b/ui/main/src/main/kotlin/org/elnix/dragonlauncher/ui/settings/customization/WidgetsTab.kt
@@ -163,7 +163,7 @@ fun WidgetsTab(
             if (selected != null) {
                 selected = null
             } else {
-                navigator.onBack()
+                widgetsViewModel.save { navigator.onBack() }
             }
         },
         helpText = stringResource(R.string.widgets_tab_help),

--- a/ui/main/src/main/kotlin/org/elnix/dragonlauncher/ui/settings/customization/WidgetsTab.kt
+++ b/ui/main/src/main/kotlin/org/elnix/dragonlauncher/ui/settings/customization/WidgetsTab.kt
@@ -163,7 +163,8 @@ fun WidgetsTab(
             if (selected != null) {
                 selected = null
             } else {
-                widgetsViewModel.save { navigator.onBack() }
+                widgetsViewModel.save()
+                navigator.onBack()
             }
         },
         helpText = stringResource(R.string.widgets_tab_help),


### PR DESCRIPTION
When returning from the widget settings screen, the `save` function of `WidgetsViewModel` is called to save the widget before returning to the previous screen.
This is a fix for Issue #399.
We followed the steps to reproduce the issue and confirmed that the behavior is now as expected.