### PR TITLE
fix app searching when some Japanese characters are included at query

### DIFF
--- a/core/i18n/src/main/kotlin/org/elnix/dragonlauncher/CompatStringNormalizer.kt
+++ b/core/i18n/src/main/kotlin/org/elnix/dragonlauncher/CompatStringNormalizer.kt
@@ -1,6 +1,6 @@
 package org.elnix.dragonlauncher
 
-import org.apache.commons.lang3.StringUtils
+import java.text.Normalizer
 import java.util.Locale
 
 /**
@@ -11,7 +11,14 @@ internal class CompatStringNormalizer: StringNormalizer  {
     override val id: String = "null"
 
     override fun normalize(input: String): String {
-        return StringUtils.stripAccents(input.lowercase(Locale.getDefault()))
+        val nfd = Normalizer.normalize(input.lowercase(Locale.getDefault()), Normalizer.Form.NFD)
+
+        // strip accents (keep Japanese voiced mark and semi-voicing mark)
+        val stripped = nfd.replace(Regex("[\\p{M}&&[^\\u3099\\u309A]]"), "")
+        // The result is similar to StringUtils.stripAccents
+        val nfc = Normalizer.normalize(stripped, Normalizer.Form.NFC);
+
+        return nfc
             .replace("æ", "ae")
             .replace("œ", "oe")
             .replace("ß", "ss")


### PR DESCRIPTION
This fix resolves a bug that prevented aliases from being searched properly when the search query contained Japanese characters with a “dakuon” or “handakuon”.

## Probrem

1. Use Japanese characters with symbols such as 「ぎ」(gi) or 「ぱ」(pa) in the alias.
<img height="445" alt="Screenshot_20260824-135512" src="https://github.com/user-attachments/assets/1a9eedb4-34b6-4b45-ba42-dcd39fef0dbb" />

2. Search using the character.
3. The app in question is not displayed.
<img height="220" alt="Screenshot_20260824-135527" src="https://github.com/user-attachments/assets/0f171c16-1679-410e-99dc-3e57788685d8" />

## Correction result
Apps that use specific characters in their aliases will display correctly.

<img height="225" alt="Screenshot_20260824-135736" src="https://github.com/user-attachments/assets/59fb8677-e9b4-4682-b156-8e5cdefcd4cd" />

